### PR TITLE
2023-01-15 Protego Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,48 @@
-# protego
+# Protego
 
 Protego is a tool to permissionlessly deploy a spell which can be used to drop a particular plan in MakerDAO's Pause contract, or in extreme cases the protego contract can itself be lifted to the hat, allowing any user to permissionlessly drop any scheduled plan.
 
+## Context
+
+* A `plan` is a scheduled `delegatecall` that exists in [the pause](https://github.com/dapphub/ds-pause) and can be permissionlessly executed. 
+* Plans in `DsPause` are [identified by a unique 32 byte hash](https://github.com/dapphub/ds-pause/blob/master/src/pause.sol#L67).
+* A conformant spell here is one where the values returned by `action()`, `tag()`, `sig()` and `eta()` are equal to the corresponding `plan`'s `usr`, `tag`, `fax` and `eta` values respectively. Bad actors could potentially manipulate the return values of these functions such that they are not equal; which would result in a nonconformant spell.
+
 ## Usage
 
-### Drop an individual plan
+### Create a single drop spell
 
-Protego contains a factory to permissionlessly create a spell that is able to drop a single plan in the [pause](https://github.com/dapphub/ds-pause).
+If there is sufficient ecosystem interest to cancel (`drop`) a particular scheduled set of actions (the target `plan`), Protego contains a factory which allows for permissionless deployment of a Spell ('drop spell') which - when elected as the hat - drops a targeted plan in the pause via two permissionless methods:
 
-* `function deploy(DSSpellLike _spell) external returns (address)`
+1) For conformant spells, `deploy(TARGET_SPELL)` will create a drop spell targeting a plan in the pause by using the values that the spell provides
+2) For nonconformant spells, `deploy(TARGET_PLAN_USR, TARGET_PLAN_TAG, TARGET_PLAN_FAX, TARGET_PLAN_ETA)` will create a drop spell targeting a plan in the pause using manually provided values
 
-Used to deploy a single spell that can be elected to a privileged position. This requires that the `_spell` address parameter conforms to a MakerDAO conformant [spell](https://github.com/makerdao/spells-mainnet)
+In this way, dishonesty by bad actors (false Spell return values) cannot be used to circumvent Protego drop spell deployment.
 
-* `function deploy(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) external returns (address)`
+### Enable permissionless dropping of all plans
 
-Used to deploy a single spell that can be elected to a privileged position. This can be used to drop a non-conformant spell by reproducing the associated components of the plan.
+In the event of a governance attack, numerous spells could be created via `plot` by an attacker at a rate faster than a single hat spell can `drop` them. To ameliorate this risk, the `Protego` contract can be elected as the hat, which would make it the `authority` on the pause. Protego contains two permissionless methods which allow for anyone to `drop` *any* `plan` permissionlessly:
 
-### Drop any plan
+1) For conformant spells, `drop(TARGET_SPELL)` will *immediately `drop`* a plan in the pause by using the values that the spell provides
+2) For nonconformant spells, `drop(TARGET_PLAN_USR, TARGET_PLAN_TAG, TARGET_PLAN_FAX, TARGET_PLAN_ETA)` will create a drop spell targeting a plan in the pause using manually provided values
 
-In the case of a governance attack, many spells could be plotted quickly by an attacker. To ameliorate this risk, the `protego` contract itself can be elected to a hat role, which permits any user to permissionlessly drop any plan.
-
-* `function drop(DSSpellLike _spell) external`
-
-Drop a conformant spell from the pause.
-
-* `function drop(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public`
-
-Drop a plan from the pause by reproducing the associated components of the plan.
+It should be noted that these functions will revert if Protego has not been elected as the hat (due to `auth` on the `drop` function in DsPause). It should also be noted that this behaviour allows for any plans to be dropped (including those not part of a governance attack).
 
 ## Additional Functions
 
-### ID
+### id()
 
 * `function id(DSSpellLike _spell) public view returns (bytes32)`
 * `function id(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public pure returns (bytes32)`
 
-Return the `bytes32` id of a plan in the pause.
+`id` returns the `bytes32` id of a given plan using the same method that `hash` does in the pause
 
-### Planned
+### planned()
 
 * `function planned(DSSpellLike _spell) public view returns (bool)`
 * `function planned(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public view returns (bool)`
 * `function planned(bytes32 _id) public view returns (bool)`
 
-Returns `true` if a plan has been plotted.
+`planned` returns `true` if a plan has been plotted (scheduled for execution)
 
 

--- a/src/Protego.sol
+++ b/src/Protego.sol
@@ -15,7 +15,7 @@ interface DSSpellLike {
 }
 
 contract Spell {
-    Protego            immutable protego;
+    Protego            immutable protego; //NOTE
     DSPauseLike public immutable pause;
     address     public immutable action;
     bytes32     public immutable tag;
@@ -48,53 +48,54 @@ contract Protego {
 
     address public immutable pause;
 
-    event NewDropSpell(address spell);
-    event NewDrop(bytes32 id);
+    event DropSpellCreated(address spell);
+    event DroppedPlan(bytes32 id);
 
     constructor(address _pause) {
         pause = _pause;
     }
 
-    // Deploy a spell to drop a conformant DssSpell
+    // Target a single plan
+
+    // Deploy a drop spell to drop a conformant DssSpell's corresponding plan
     function deploy(DSSpellLike _spell) external returns (address) {
         return _deploy(_spell.action(), _spell.tag(), _spell.sig(), _spell.eta());
     }
 
-    // Deploy a spell to drop a plan based on attributes
+    // Deploy a drop spell to drop a specific plan based on its attributes
     function deploy(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) external returns (address) {
         return _deploy(_usr, _tag, _fax, _eta);
     }
 
     function _deploy(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) internal returns (address _spell) {
         _spell = address(new Spell(address(this), pause, _usr, _tag, _fax, _eta));
-        emit NewDropSpell(_spell);
+        emit DropSpellCreated(_spell);
     }
 
-    // Calculate the plan id for a set of attributes
+    // Calculate a plan's id / hash based on its attributes
     function id(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public pure returns (bytes32) {
         return keccak256(abi.encode(_usr, _tag, _fax, _eta));
     }
 
-    // Calculate the plan id of a conformant DssSpell
+    // Calculate a conformant DssSpell's plan id / hash
     function id(DSSpellLike _spell) public view returns (bytes32) {
         return id(_spell.action(), _spell.tag(), _spell.sig(), _spell.eta());
     }
 
-    // Return true if a plan matching the set of attributes is currently planned
+    // Return true if a plan matching the set of attributes is currently scheduled for execution
     function planned(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public view returns (bool) {
         return planned(id(_usr, _tag, _fax, _eta));
     }
 
-    // Return true if a conformant DssSpell is planned
+    // Return true if a conformant DssSpell is scheduled for execution
     function planned(DSSpellLike _spell) public view returns (bool) {
         return planned(id(_spell));
     }
 
-    // Return true if an id is planned
+    // Return true if a plan with the given id / hash is scheduled for execution
     function planned(bytes32 _id) public view returns (bool) {
         return DSPauseLike(pause).plans(_id);
     }
-
 
     // Permissionlessly block everything
     // Note: In some cases, due to a governance attack or other unforseen
@@ -105,11 +106,14 @@ contract Protego {
     //       drop any id from the pause.
     //       This function is expected to revert if it does not have the
     //       authority to perform this function.
+
+    // Drop a specific plan based on its attributes
     function drop(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public {
         DSPauseLike(pause).drop(_usr, _tag, _fax, _eta);
-        emit NewDrop(id(_usr, _tag, _fax, _eta));
+        emit DroppedPlan(id(_usr, _tag, _fax, _eta));
     }
 
+    // Drop a conformant DssSpell's corresponding plan
     function drop(DSSpellLike _spell) external {
         drop(_spell.action(), _spell.tag(), _spell.sig(), _spell.eta());
     }

--- a/src/Protego.t.sol
+++ b/src/Protego.t.sol
@@ -215,6 +215,7 @@ contract ProtegoTest is Test {
         assertEq(protego.pause(), address(pause));
     }
 
+    // Test creation of drop spell for conformant target spell
     function testDeploySpell() external {
         DssEndTestSpell badSpell = new DssEndTestSpell(address(pause), address(end));
 
@@ -231,6 +232,7 @@ contract ProtegoTest is Test {
         assertEq(protego.id(DSSpellLike(goodSpell)), protego.id(usr, tag, sig, eta));
     }
 
+    // Test creation of drop spell for nonconformant target spell
     function testDeploySpellParams() external {
         DssEndTestSpell badSpell = new DssEndTestSpell(address(pause), address(end));
 
@@ -313,7 +315,7 @@ contract ProtegoTest is Test {
         assertTrue(!protego.planned(DSSpellLike(address(badSpell))));
     }
 
-    // Test drop of spell created with params
+    // Test drop of nonconformant spell
     function testDropSpellParams() external {
         DssEndTestSpell badSpell = new DssEndTestSpell(address(pause), address(end));
 
@@ -340,7 +342,7 @@ contract ProtegoTest is Test {
         assertTrue(!protego.planned(DSSpellLike(address(badSpell))));
     }
 
-    // Test drop anything by lifting Protego to hat
+    // Test drop anything (conformant) by lifting Protego to hat
     function testDropAllSpells() external {
 
         uint256 iter = 100;
@@ -368,7 +370,7 @@ contract ProtegoTest is Test {
         }
     }
 
-    // Test drop anything by lifting Protego to hat
+    // Test drop anything (nonconformant) by lifting Protego to hat
     function testDropAllSpellsParams() external {
 
         uint256 iter = 100;


### PR DESCRIPTION
Hi, here is my Protego review. My foundry is a bit broken right now so I didn't double check if the tests work locally but I don't think I made any major functional changes.

### Abstract and Rationale

Protego allows spell deployment with the intention of dropped existing plans (not spells). This can be used to mitigate damage from governance attacks. A plan is a scheduled delegatecall that can be permissionlessly executed. (Note that I'm unsure why PP exec is authed when there is a permissionless way to call exec - need context on that...)

The rationale for Protego is that a `plan` can only be dropped by authorised users (i.e. the chief). I presume that the issue here is that a 'spam' style attack by malicious governance would involve plotting more actions than the chief can conceivably drop in a given window. Protego would allow the 'spam' to be prevented by temporarily making dropping any `plan` permissionless. While this would stall malicious governance attacks, it would also allow *any* `plan` to be dropped permissionlessly and therefore halt all progress.

Protego also contains the ability to drop an individual `plan` (rather than making all `drop` operations permissionless via electing as the chief).

The core logic here is that `deploy` takes either a `DsSpell` or the plan arguments and then creates a `Spell` instance which can do three things:
- `description()` returns the hash of the plan being targeted by the drop spell
- `planned()` returns true if the spell is planned
- `cast()` calls `drop` on `DsPause` for the targeted `plan` (cancels the plan)

Overall, protego solves two problems:
1) Spell creation to `drop` a plan in `Pause` is now permissionless (i.e. anyone can create the spell which can then be voted to `hat` position, meaning that individual community members have the ability to easily 'veto' a spell if this were necessary).
2) Spam attacks by malicious governance can now be fought more effectively

### Docs

[`> ameliorate`](https://i.kym-cdn.com/photos/images/newsfeed/000/343/462/79a.gif)

I added context since if this is meant to be permissionless it shouldn't take people an hour to understand what is going on and it is now more user-friendly for less technical folks. Use this at your discretion but I made it very easy to understand for normal folks (IMO).

### Base Contract

- Interfaces OK
- NOTE `Protego immutable protego;` has no explicit visibility, should we use public or internal (default)? 
- NOTE: `bytes public sig;` doesn't have the `immutable` tag but cannot be changed in any way; I assume this is Solidity not liking dynamically sized bytes being immutable? Or is there some other reasoning here?
- NOTE: Do we *need* `description` and `planned` in the drop spell? They're already in protego. It would save us 1 storage slot per drop spell (IMO I would have it in protego only) ==> I did this before in this branch but I added it back in, up to you if you want to remove it
- NOTE: I renamed 'NewDropSpell' to 'DropSpellCreated' and 'NewDrop' to 'DroppedPlan' to make the events reflect what actually happened
- I changed 'planned' in the comments to 'scheduled for execution' to reduce confusion
- NOTE: `DssSpell` in the comments, `DsSpell` per the code [here](https://github.com/dapphub/ds-spell/blob/master/src/spell.sol) - what do we want to use?
- Originally I didn't like how `fax` was `sig` and `usr` was `action` but I see that they refer to the values that the *spell* gives us and make a trust assumption. We could call it `spell_usr` or something since otherwise there is no differentiating factor for stuff like `eta` but I am OK with it as is.
- Everything else OK, I added some comments and changed some wording for use at your discretion

### Test Contract

- Tests are pretty comprehensive and check for all cases I would check for (I added some comments)
