### PR TITLE
feature: Drop multiple plans in a single call

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,5 +12,8 @@ fs_permissions = [
     { access = "read-write", path = "./script/output/" }
 ]
 
+[fuzz]
+runs = 1_000
+
 [rpc_endpoints]
 mainnet = "${ETH_RPC_URL}"

--- a/script/dependencies/ProtegoDeploy.sol
+++ b/script/dependencies/ProtegoDeploy.sol
@@ -25,6 +25,6 @@ struct ProtegoDeployParams {
 
 library ProtegoDeploy {
     function deploy(ProtegoDeployParams memory p) internal returns (ProtegoInstance memory r) {
-      r.protego = address(new Protego(p.pause));
+        r.protego = address(new Protego(p.pause));
     }
 }

--- a/script/dependencies/ProtegoInstance.sol
+++ b/script/dependencies/ProtegoInstance.sol
@@ -18,4 +18,3 @@ pragma solidity ^0.8.16;
 struct ProtegoInstance {
     address protego;
 }
-

--- a/src/EmergencyDropSpell.sol
+++ b/src/EmergencyDropSpell.sol
@@ -64,8 +64,10 @@ contract EmergencyDropSpell is EmergencySpellLike {
     uint256 public immutable eta;
     /// @notice The original spell encoded call.
     bytes public sig;
-    // @dev An emergency spell does not need to be cast, as all actions happen during the schedule phase.
-    //      Notice that cast is usually not supposed to revert, so it is implemented as a no-op.
+    /**
+     * @dev An emergency spell does not need to be cast, as all actions happen during the schedule phase.
+     *      Notice that cast is usually not supposed to revert, so it is implemented as a no-op.
+     */
     uint256 public immutable nextCastTime = type(uint256).max;
 
     /// @notice Drop have been called.

--- a/src/Protego.sol
+++ b/src/Protego.sol
@@ -122,11 +122,11 @@ contract Protego {
      * @notice Drop multiple plans in a single call.
      * @dev If an empty array is passed, no spells are dropped and nothing happens as
      *      `DsPauseLike::drop` is not called.
-     * @param plans An array of plans to drop.
+     * @param _plans An array of plans to drop.
      */
-    function drop(Plan[] calldata plans) external {
-        for (uint256 i; i < plans.length;) {
-            drop(plans[i].usr, plans[i].tag, plans[i].fax, plans[i].eta);
+    function drop(Plan[] calldata _plans) external {
+        for (uint256 i; i < _plans.length;) {
+            drop(_plans[i].usr, _plans[i].tag, _plans[i].fax, _plans[i].eta);
 
             unchecked {
                 i++;

--- a/src/Protego.sol
+++ b/src/Protego.sol
@@ -88,19 +88,33 @@ contract Protego {
     }
 
     /**
+     * @notice A struct representing a plan.
+     * @param usr The address of the scheduled spell.
+     * @param tag The tag identifying the address.
+     * @param fax The encoded call to be made in `usr`.
+     * @param eta The expiration time.
+     */
+    struct Plan {
+        address usr;
+        bytes32 tag;
+        bytes fax;
+        uint256 eta;
+    }
+
+    /**
      * @notice Permissionlessly drop anything that has been planned on the pause.
      * @dev In some cases, due to a faulty spell being voted, a governance attack or other unforseen causes, it may be
      *      necessary to block any spell that is entered into the pause proxy.
      *      In this extreme case, the system can be protected during the pause delay by lifting the Protego contract to
      *      the hat role, which will allow any user to permissionlessly drop any id from the pause.
      *      This function is expected to revert if it does not have the authority to perform this function.
-     * @param _usr The address of the scheduled spell.
-     * @param _tag The tag identifying the address.
-     * @param _fax The encoded call to be made in `_usr`.
-     * @param _eta The expiration time.
+     * @dev This function supports dropping multiple scheduled plans in a single call.
+     * @param plans An array of plans to drop.
      */
-    function drop(address _usr, bytes32 _tag, bytes memory _fax, uint256 _eta) public {
-        DsPauseLike(pause).drop(_usr, _tag, _fax, _eta);
-        emit Drop(id(_usr, _tag, _fax, _eta));
+    function drop(Plan[] calldata plans) external {
+        for (uint256 i; i < plans.length; i++) {
+            DsPauseLike(pause).drop(plans[i].usr, plans[i].tag, plans[i].fax, plans[i].eta);
+            emit Drop(id(plans[i].usr, plans[i].tag, plans[i].fax, plans[i].eta));
+        }
     }
 }

--- a/src/Protego.t.sol
+++ b/src/Protego.t.sol
@@ -154,7 +154,7 @@ contract ProtegoTest is DssTest {
         uint256 iter = 10;
         BadSpells[] memory badSpells = new BadSpells[](iter);
 
-        for (uint256 i = 0; i < iter; i++) {
+        for (uint256 i; i < iter; i++) {
             ConformingSpell badSpell = new ConformingSpell(pause, end);
             _vote(address(badSpell));
             badSpell.schedule();
@@ -171,7 +171,7 @@ contract ProtegoTest is DssTest {
 
         Protego.Plan[] memory plans = new Protego.Plan[](iter);
 
-        for (uint256 i = 0; i < iter; i++) {
+        for (uint256 i; i < iter; i++) {
             plans[i] = Protego.Plan({
                 usr: badSpells[i].action,
                 tag: badSpells[i].tag,
@@ -184,7 +184,7 @@ contract ProtegoTest is DssTest {
 
         protego.drop(plans);
 
-        for (uint256 i = 0; i < iter; i++) {
+        for (uint256 i; i < iter; i++) {
             assertFalse(protego.planned(badSpells[i].action, badSpells[i].tag, badSpells[i].sig, badSpells[i].eta));
         }
 

--- a/src/Protego.t.sol
+++ b/src/Protego.t.sol
@@ -169,18 +169,29 @@ contract ProtegoTest is DssTest {
 
         _vote(address(protego));
 
+        Protego.Plan[] memory plans = new Protego.Plan[](iter);
+
         for (uint256 i = 0; i < iter; i++) {
+            plans[i] = Protego.Plan({
+                usr: badSpells[i].action,
+                tag: badSpells[i].tag,
+                fax: badSpells[i].sig,
+                eta: badSpells[i].eta
+            });
             vm.expectEmit(true, true, true, true);
             emit Drop(protego.id(badSpells[i].action, badSpells[i].tag, badSpells[i].sig, badSpells[i].eta));
-            protego.drop(badSpells[i].action, badSpells[i].tag, badSpells[i].sig, badSpells[i].eta);
+        }
 
+        protego.drop(plans);
+
+        for (uint256 i = 0; i < iter; i++) {
             assertFalse(protego.planned(badSpells[i].action, badSpells[i].tag, badSpells[i].sig, badSpells[i].eta));
         }
 
         // After Protego loses the hat, it can no longer drop spells
         _vote(address(0));
         vm.expectRevert("ds-auth-unauthorized");
-        protego.drop(badSpells[0].action, badSpells[0].tag, badSpells[0].sig, badSpells[0].eta);
+        protego.drop(plans);
     }
 
     function _vote(address spell_) internal {

--- a/src/test/NonConformingSpell.sol
+++ b/src/test/NonConformingSpell.sol
@@ -36,5 +36,3 @@ contract NonConformingSpell {
         return pause.exec(usr, tag, fax, eta);
     }
 }
-
-


### PR DESCRIPTION
# Feature: Drop multiple plans in a single call

The main goal of this PR is to introduce the new `Protego::drop(Plan[] calldata _plans)` function, that supports taking an array of `n` plans and dropping them by reusing the existing `Protego::drop` single drop function. It also updates tests to cover the introduced scenarios and implements a few general improvements to the codebase, by, for example, fixing small typos and fuzzing the amount of iterations when testing the new multi drop feature.

