### PR TITLE
fix: force ending CLI process after listing results

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -84,6 +84,8 @@ async function run({ rpcUrl, fromBlock, status, pauseAddress, format }) {
         } else {
             console.log(createJson(plans));
         }
+
+        process.exit(0);
     } catch (error) {
         spinner.error("Failed!");
         console.error(chalk.red("An error occurred:", error));


### PR DESCRIPTION
End process after returning results on the CLI to avoid execution being stuck when using `wss` RPC providers.