### PR TITLE
Docs: Explicitly add `@latest` to the package name when using `npx`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -5,7 +5,7 @@
 ### CLI
 
 ```
-npx @dewiz-xyz/protego [-V -h] | --rpc-url <rpc-url> [--from-block 19420069] [--status PENDING] [--pause-address <addr>] [--format TABLE]
+npx @dewiz-xyz/protego@latest [-V -h] | --rpc-url <rpc-url> [--from-block 19420069] [--status PENDING] [--pause-address <addr>] [--format TABLE]
 ```
 
 All options:


### PR DESCRIPTION
Force `npx` to always use the latest version available, not the cached one.